### PR TITLE
Update database to use a docker volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     restart: always
     image: tbackman/debian-cheminformatics:debian10
     command: ["/usr/lib/postgresql/11/bin/postgres", "-D", "/var/lib/postgresql/11/main", "-c", "config_file=/etc/postgresql/11/main/postgresql.conf"]
+    volumes:
+      - app-db-data:/var/lib/postgresql/11/main
   redis:
     restart: always
     image: redis:3.2-alpine 
@@ -36,3 +38,6 @@ services:
       - web
     links:
       - web:web
+
+volumes:
+  app-db-data:


### PR DESCRIPTION
By using a docker volume as the database storage location, we enable the clusterCAD stack to be stopped and restarted without having to reload the database which takes at least 20 minutes.

For example, after loading the database once, we can now do this:
```
(py37) [ 10:08AM ]  [ albertonava@AANava-M65:~/Desktop/web_projects/clustercad(database-volume✗) ]
 $ docker-compose exec web python3 -c 'import os, sys, re;sys.path.insert(0, "/clusterCAD");os.environ.setdefault("DJANGO_SETTINGS_MODULE", "clusterCAD.settings");import django;django.setup();import pks.models;print(len(pks.models.Module.objects.all()))'
1077
(py37) [ 10:09AM ]  [ albertonava@AANava-M65:~/Desktop/web_projects/clustercad(database-volume✗) ]
 $ docker-compose stop
Stopping clustercad_nginx_1 ... done
Stopping clustercad_web_1   ... done
Stopping clustercad_db_1    ... done
Stopping clustercad_redis_1 ... done
(py37) [ 10:10AM ]  [ albertonava@AANava-M65:~/Desktop/web_projects/clustercad(database-volume✗) ]
 $ docker-compose up -d
Starting clustercad_db_1    ... done
Starting clustercad_redis_1 ... done
Starting clustercad_web_1   ... done
Starting clustercad_nginx_1 ... done
(py37) [ 10:11AM ]  [ albertonava@AANava-M65:~/Desktop/web_projects/clustercad(database-volume✗) ]
 $ docker-compose exec web python3 -c 'import os, sys, re;sys.path.insert(0, "/clusterCAD");os.environ.setdefault("DJANGO_SETTINGS_MODULE", "clusterCAD.settings");import django;django.setup();import pks.models;print(len(pks.models.Module.objects.all()))'
1077
(py37) [ 10:11AM ]  [ albertonava@AANava-M65:~/Desktop/web_projects/clustercad(database-volume✗) ]
 $ docker-compose down
Stopping clustercad_nginx_1 ... done
Stopping clustercad_web_1   ... done
Stopping clustercad_db_1    ... done
Stopping clustercad_redis_1 ... done
Removing clustercad_nginx_1 ... done
Removing clustercad_web_1   ... done
Removing clustercad_db_1    ... done
Removing clustercad_redis_1 ... done
Removing network clustercad_default
(py37) [ 10:11AM ]  [ albertonava@AANava-M65:~/Desktop/web_projects/clustercad(database-volume✗) ]
 $ docker-compose up -d
Creating network "clustercad_default" with the default driver
Creating clustercad_db_1    ... done
Creating clustercad_redis_1 ... done
Creating clustercad_web_1   ... done
Creating clustercad_nginx_1 ... done
(py37) [ 10:11AM ]  [ albertonava@AANava-M65:~/Desktop/web_projects/clustercad(database-volume✗) ]
 $ docker-compose exec web python3 -c 'import os, sys, re;sys.path.insert(0, "/clusterCAD");os.environ.setdefault("DJANGO_SETTINGS_MODULE", "clusterCAD.settings");import django;django.setup();import pks.models;print(len(pks.models.Module.objects.all()))'
1077
```